### PR TITLE
add `whenPaused` modifier

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -715,7 +715,7 @@ contract BlueberryStaking is
      * @notice Sets the  stable asset to an alternative in the event of a depeg
      * @param _stableAsset The new stable asset address
      */
-    function setStableAsset(address _stableAsset) external onlyOwner {
+    function setStableAsset(address _stableAsset) external whenPaused onlyOwner {
         if (_stableAsset == address(0)) {
             revert AddressZero();
         }
@@ -748,7 +748,7 @@ contract BlueberryStaking is
     function setUniswapV3Pool(
         address _uniswapPool,
         uint32 _observationPeriod
-    ) external onlyOwner {
+    ) external whenPaused onlyOwner {
         if (_uniswapPool == address(0)) {
             revert AddressZero();
         }

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -761,7 +761,7 @@ contract BlueberryStaking is
         uniswapV3Info = UniswapV3PoolInfo({
             pool: _uniswapPool,
             observationPeriod: _observationPeriod,
-            blbIsToken0: IUniswapV3Pool(_uniswapPool).token0() == address(blb)
+            blbIsToken0: blbIsToken0
         });
 
         uint8 decimals = IERC20Metadata(_stableAsset).decimals();

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -738,7 +738,7 @@ contract BlueberryStaking is
         address _uniswapPool,
         address _stableAsset,
         uint32 _observationPeriod
-    ) external whenPaused onlyOwner {
+    ) external onlyOwner {
         if (_uniswapPool == address(0) || _stableAsset == address(0)) {
             revert AddressZero();
         }

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -746,11 +746,16 @@ contract BlueberryStaking is
             revert InvalidObservationTime();
         }
         
-        address token0 = IUniswapV3Pool(_uniswapPool).token0();
-        address token1 = IUniswapV3Pool(_uniswapPool).token1();
+        bool blbIsToken0 = IUniswapV3Pool(_uniswapPool).token0() == address(blb);
 
-        if (_stableAsset != token0 && _stableAsset != token1) {
-            revert InvalidStableAsset();
+        if (blbIsToken0) {
+            address token1 =IUniswapV3Pool(_uniswapPool).token1();
+            if (token1 != _stableAsset) revert InvalidStableAsset();
+            stableAsset = IERC20(token1);
+        } else {
+            address token0 = IUniswapV3Pool(_uniswapPool).token0();
+            if (token0 != _stableAsset) revert InvalidStableAsset();
+            stableAsset = IERC20(token0);
         }
 
         uniswapV3Info = UniswapV3PoolInfo({
@@ -759,7 +764,6 @@ contract BlueberryStaking is
             blbIsToken0: IUniswapV3Pool(_uniswapPool).token0() == address(blb)
         });
 
-        stableAsset = IERC20(_stableAsset);
         uint8 decimals = IERC20Metadata(_stableAsset).decimals();
         stableDecimals = decimals;
 

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -37,6 +37,9 @@ interface IBlueberryStaking {
     /// @notice Emitted if the observation time on the uniswap pool is greater than 432,000 seconds.
     error InvalidObservationTime();
 
+    /// @notice Emitted if the stable asset is not in the uniswap pool.
+    error InvalidStableAsset();
+
     /// @notice Emitted if a bToken being added already exists.
     error IBTokenAlreadyExists();
 
@@ -87,8 +90,13 @@ interface IBlueberryStaking {
     /// @notice Emitted when the admin updates the treasury address.
     event TreasuryUpdated(address treasury);
 
-    /// @notice Emitted when the admin updates the stable asset.
-    event StableAssetUpdated(address asset, uint256 decimals);
+    /// @notice Emitted when the admin updates the uniswap pool.
+    event UniswapV3PoolUpdated(
+        address _uniswapPool,
+        address _stableAsset,
+        uint8 decimals,
+        uint256 _observationPeriod
+    );
 
     /// @notice Emitted when the treasury collects fees from the acceleration of vesting schedules.
     event FeeCollected(address indexed user, uint256 amount);

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -92,10 +92,10 @@ interface IBlueberryStaking {
 
     /// @notice Emitted when the admin updates the uniswap pool.
     event UniswapV3PoolUpdated(
-        address _uniswapPool,
-        address _stableAsset,
+        address uniswapPool,
+        address stableAsset,
         uint8 decimals,
-        uint256 _observationPeriod
+        uint256 observationPeriod
     );
 
     /// @notice Emitted when the treasury collects fees from the acceleration of vesting schedules.

--- a/test/Control.t.sol
+++ b/test/Control.t.sol
@@ -24,11 +24,18 @@ contract Control is Test {
 
     address[] public existingIbTokens;
 
+    address USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
     // Initial reward duration
     uint256 public constant REWARD_DURATION = 1_209_600;
 
+    uint256 mainnetFork;
+    string MAINNET_RPC_URL = vm.envString("MAINNET_RPC_URL");
+
     // Initialize the contract and deploy necessary instances
     function setUp() public {
+        mainnetFork = vm.createFork(MAINNET_RPC_URL);
+        vm.selectFork(mainnetFork);
         vm.startPrank(owner);
         // Deploy mock tokens and BlueberryToken
         mockIbToken1 = new MockIbToken();
@@ -183,18 +190,20 @@ contract Control is Test {
         assertEq(blb.balanceOf(address(blueberryStaking)),(1e19 + (1e19 * 4) + (1e23 * 4)));
     }
 
-    // Test changing the stable token address
-    function testChangeStable() public {
+    // Test changing the uniswap pool
+    function testChangeUniswapPool() public {
         vm.startPrank(owner);
-
-        // Deploy a new stable coin 
-        MockToken token = new MockToken(9);
+        blueberryStaking.pause();
         
-        // Change the stable token to be the mock token with 9 decimals instead of the original 6 decimal token
-        blueberryStaking.setStableAsset(address(token));
+        // Change the uniswap pool to a new stable asset
+        blueberryStaking.setUniswapV3Pool(
+            0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640,
+            USDC,
+            3600
+        );
 
         // Check that the stable token address was updated correctly
-        assertEq(address(blueberryStaking.stableAsset()), address(token));
+        assertEq(address(blueberryStaking.stableAsset()), USDC);
     }
 
     function testChangeRewardAmount() public {

--- a/test/Control.t.sol
+++ b/test/Control.t.sol
@@ -24,7 +24,9 @@ contract Control is Test {
 
     address[] public existingIbTokens;
 
+    address UNIPOOL_ETH_USDC =0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640;
     address USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
 
     // Initial reward duration
     uint256 public constant REWARD_DURATION = 1_209_600;
@@ -196,13 +198,22 @@ contract Control is Test {
         
         // Change the uniswap pool to a new stable asset
         blueberryStaking.setUniswapV3Pool(
-            0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640,
+            UNIPOOL_ETH_USDC,
             USDC,
             3600
         );
 
         // Check that the stable token address was updated correctly
         assertEq(address(blueberryStaking.stableAsset()), USDC);
+
+        // Expect the pool to revert since the stable asset is not in that pool
+        vm.expectRevert();
+        // Change the uniswap pool to a new stable asset
+        blueberryStaking.setUniswapV3Pool(
+            UNIPOOL_ETH_USDC,
+            DAI,
+            3600
+        );
     }
 
     function testChangeRewardAmount() public {

--- a/test/Control.t.sol
+++ b/test/Control.t.sol
@@ -193,7 +193,6 @@ contract Control is Test {
     // Test changing the uniswap pool
     function testChangeUniswapPool() public {
         vm.startPrank(owner);
-        blueberryStaking.pause();
         
         // Change the uniswap pool to a new stable asset
         blueberryStaking.setUniswapV3Pool(

--- a/test/Control.t.sol
+++ b/test/Control.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../lib/forge-std/src/Test.sol";
 import {TransparentUpgradeableProxy} from "openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import {BlueberryStaking} from "../src/BlueberryStaking.sol";
+import {BlueberryStaking, IBlueberryStaking} from "../src/BlueberryStaking.sol";
 import {BlueberryToken} from "../src/BlueberryToken.sol";
 import {MockIbToken} from "./mocks/MockIbToken.sol";
 import {MockUSDC} from "./mocks/MockUSDC.sol";
@@ -207,7 +207,7 @@ contract Control is Test {
         assertEq(address(blueberryStaking.stableAsset()), USDC);
 
         // Expect the pool to revert since the stable asset is not in that pool
-        vm.expectRevert();
+        vm.expectRevert(IBlueberryStaking.InvalidStableAsset.selector);
         // Change the uniswap pool to a new stable asset
         blueberryStaking.setUniswapV3Pool(
             UNIPOOL_ETH_USDC,


### PR DESCRIPTION
<!-- If this is deployment-related, please go the the Preview tab and select the appropriate sub-template. -->
<!-- Otherwise, delete everything before #Description -->

# Description
Add the `whenPaused` modifer to admin setters to ensure no mismatch of pools and stable asset.
<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->

## Type of change

- [X] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
