### PR TITLE
Reward duration caching

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -679,7 +679,7 @@ contract BlueberryStaking is
 
             _setRewardRate(_ibToken, _amount, _rewardDuration);
             lastUpdateTime[_ibToken] = block.timestamp;
-            finishAt[_ibToken] = block.timestamp + rewardDuration;
+            finishAt[_ibToken] = block.timestamp + _rewardDuration;
 
             emit RewardAmountModified(_ibToken, _amount);
         }


### PR DESCRIPTION
# Description

Within `modifyRewardAmount` the storage variable `rewardDuration` is cached using the local variable `_rewardDuration` and used throughout the function. In line 682 we incorrectly use the storage instance of `rewardDuration` to calculated `finishAt[_ibToken]`. Instead we should used its cached instance `_rewardDuration` to decrease storage reads and save gas.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
