### PR TITLE
Update the Vest struct to take up 2 storage slots instead of 4

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -293,7 +293,7 @@ contract BlueberryStaking is
     function startVesting(
         address[] calldata _ibTokens
     ) external whenNotPaused updateRewards(msg.sender, _ibTokens) {
-        uint256 totalRewards;
+        uint128 totalRewards;
 
         uint256 _ibTokensLength = _ibTokens.length;
         for (uint256 i; i < _ibTokensLength; ++i) {
@@ -307,16 +307,14 @@ contract BlueberryStaking is
             if (reward > 0) {
                 totalRewards += reward;
                 rewards[msg.sender][address(_ibToken)] = 0;
-
-                uint128 _priceUnderlying = getPrice();
-
-                vesting[msg.sender].push(
-                    Vest(reward, 0, uint128(block.timestamp), _priceUnderlying)
-                );
             }
         }
 
         totalVestAmount += totalRewards;
+
+        vesting[msg.sender].push(
+            Vest(totalRewards, 0, uint128(block.timestamp), getPrice())
+        );
 
         emit VestStarted(msg.sender, totalRewards);
     }
@@ -581,7 +579,7 @@ contract BlueberryStaking is
         );
 
         accelerationFee =
-            ((((_vest.priceUnderlying * _vestTotal) / 1e18) *
+            ((((_vest.priceInUnderlying * _vestTotal) / 1e18) *
                 _earlyUnlockPenaltyRatio) / 1e18) /
             (10 ** (18 - stableDecimals));
     }

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -118,10 +118,10 @@ contract BlueberryStaking is
     uint8 private constant BLB_DECIMALS = 18;
 
     /// @notice The price of BLB during the 1st period of the lockdrop
-    uint256 private constant PERIOD_ONE_BLB_PRICE = 0.02e18;
+    uint128 private constant PERIOD_ONE_BLB_PRICE = 0.02e18;
 
     /// @notice The price of BLB during the 2nd period of the lockdrop
-    uint256 private constant PERIOD_TWO_BLB_PRICE = 0.04e18;
+    uint128 private constant PERIOD_TWO_BLB_PRICE = 0.04e18;
 
     /*//////////////////////////////////////////////////
                         MODIFIERS
@@ -282,7 +282,7 @@ contract BlueberryStaking is
             }
 
             if (redistributedBLB > 0) {
-                vest.extra = (vest.amount * redistributedBLB) / totalVestAmount;
+                vest.extra = (vest.amount * uint128(redistributedBLB)) / uint128(totalVestAmount);
             }
         }
 
@@ -302,16 +302,16 @@ contract BlueberryStaking is
             }
 
             IERC20 _ibToken = IERC20(_ibTokens[i]);
-            uint256 reward = rewards[msg.sender][address(_ibToken)];
+            uint128 reward = uint128(rewards[msg.sender][address(_ibToken)]);
 
             if (reward > 0) {
                 totalRewards += reward;
                 rewards[msg.sender][address(_ibToken)] = 0;
 
-                uint256 _priceUnderlying = getPrice();
+                uint128 _priceUnderlying = getPrice();
 
                 vesting[msg.sender].push(
-                    Vest(reward, 0, block.timestamp, _priceUnderlying)
+                    Vest(reward, 0, uint128(block.timestamp), _priceUnderlying)
                 );
             }
         }
@@ -450,7 +450,7 @@ contract BlueberryStaking is
     //////////////////////////////////////////////////*/
 
     /// @inheritdoc IBlueberryStaking
-    function getPrice() public view returns (uint256 _price) {
+    function getPrice() public view returns (uint128 _price) {
         // during the lockdrop period the underlying blb token price is locked
         uint256 _period = (block.timestamp - deployedAt) /
             (LOCKDROP_DURATION / 2);
@@ -796,7 +796,7 @@ contract BlueberryStaking is
      * @dev A default value of $0.04 is returned if the Uniswap V3 pool is not set
      * @return The price of BLB in terms of the stable asset
      */
-    function _fetchTWAP() internal view returns (uint256) {
+    function _fetchTWAP() internal view returns (uint128) {
         UniswapV3PoolInfo memory _uniswapV3Info = uniswapV3Info;
         IUniswapV3Pool _pool = IUniswapV3Pool(_uniswapV3Info.pool);
         uint32 _observationPeriod = _uniswapV3Info.observationPeriod;
@@ -838,7 +838,7 @@ contract BlueberryStaking is
         // Now priceX96 is the price of blb in terms of stableAsset, multiplied by 2^96.
         // To convert this to a human-readable format, you can divide by 2^96:
 
-        uint256 _price = _priceX96 / 2 ** 96;
+        uint128 _price = uint128(_priceX96 / 2 ** 96);
 
         // Now 'price' is the price of blb in terms of stableAsset, in the correct decimal places.
         return _price;

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -293,7 +293,7 @@ contract BlueberryStaking is
     function startVesting(
         address[] calldata _ibTokens
     ) external whenNotPaused updateRewards(msg.sender, _ibTokens) {
-        uint128 totalRewards;
+        uint256 totalRewards;
 
         uint256 _ibTokensLength = _ibTokens.length;
         for (uint256 i; i < _ibTokensLength; ++i) {
@@ -307,14 +307,16 @@ contract BlueberryStaking is
             if (reward > 0) {
                 totalRewards += reward;
                 rewards[msg.sender][address(_ibToken)] = 0;
+
+                uint128 _priceUnderlying = getPrice();
+
+                vesting[msg.sender].push(
+                    Vest(reward, 0, uint128(block.timestamp), _priceUnderlying)
+                );
             }
         }
 
         totalVestAmount += totalRewards;
-
-        vesting[msg.sender].push(
-            Vest(totalRewards, 0, uint128(block.timestamp), getPrice())
-        );
 
         emit VestStarted(msg.sender, totalRewards);
     }
@@ -579,7 +581,7 @@ contract BlueberryStaking is
         );
 
         accelerationFee =
-            ((((_vest.priceInUnderlying * _vestTotal) / 1e18) *
+            ((((_vest.priceUnderlying * _vestTotal) / 1e18) *
                 _earlyUnlockPenaltyRatio) / 1e18) /
             (10 ** (18 - stableDecimals));
     }

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -102,13 +102,13 @@ interface IBlueberryStaking {
      * @param amount The amount of tokens vested
      * @param extra The extra amount of tokens to be redistributed to this vesting schedule
      * @param startTime The start time of the vesting schedule
-     * @param priceUnderlying The underlying token Price
+     * @param priceInUnderlying The price of BLB in the stable asset at the time of vesting
      */
     struct Vest {
         uint128 amount;
         uint128 extra;
         uint128 startTime;
-        uint128 priceUnderlying;
+        uint128 priceInUnderlying;
     }
 
     /**

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -105,10 +105,10 @@ interface IBlueberryStaking {
      * @param priceUnderlying The underlying token Price
      */
     struct Vest {
-        uint256 amount;
-        uint256 extra;
-        uint256 startTime;
-        uint256 priceUnderlying;
+        uint128 amount;
+        uint128 extra;
+        uint128 startTime;
+        uint128 priceUnderlying;
     }
 
     /**
@@ -184,7 +184,7 @@ interface IBlueberryStaking {
      * @dev Uses the Uniswap V3 TWAP pricing method after the 30 day lockdrop period in complete
      * @return _price The current price scaled to an 18 decimal fixed point number
      */
-    function getPrice() external view returns (uint256 _price);
+    function getPrice() external view returns (uint128 _price);
 
     /**
      * @return returns true if the vesting schedule is complete for the given user and vesting index

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -102,13 +102,13 @@ interface IBlueberryStaking {
      * @param amount The amount of tokens vested
      * @param extra The extra amount of tokens to be redistributed to this vesting schedule
      * @param startTime The start time of the vesting schedule
-     * @param priceInUnderlying The price of BLB in the stable asset at the time of vesting
+     * @param priceUnderlying The underlying token Price
      */
     struct Vest {
         uint128 amount;
         uint128 extra;
         uint128 startTime;
-        uint128 priceInUnderlying;
+        uint128 priceUnderlying;
     }
 
     /**


### PR DESCRIPTION
# Description

The `Vest` struct currently takes up 4 storage slots per instance. This can be reduced to 2 by changing all parameters to `uint128` instead of `uint256`.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
