### PR TITLE
Update startVesting to create 1 vest index per call

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -293,7 +293,7 @@ contract BlueberryStaking is
     function startVesting(
         address[] calldata _ibTokens
     ) external whenNotPaused updateRewards(msg.sender, _ibTokens) {
-        uint128 totalRewards;
+        uint256 totalRewards;
 
         uint256 _ibTokensLength = _ibTokens.length;
         for (uint256 i; i < _ibTokensLength; ++i) {
@@ -307,14 +307,16 @@ contract BlueberryStaking is
             if (reward > 0) {
                 totalRewards += reward;
                 rewards[msg.sender][address(_ibToken)] = 0;
+
+                uint128 _priceUnderlying = getPrice();
+
+                vesting[msg.sender].push(
+                    Vest(reward, 0, uint128(block.timestamp), _priceUnderlying)
+                );
             }
         }
 
         totalVestAmount += totalRewards;
-
-        vesting[msg.sender].push(
-            Vest(totalRewards, 0, uint128(block.timestamp), getPrice())
-        );
 
         emit VestStarted(msg.sender, totalRewards);
     }
@@ -579,7 +581,7 @@ contract BlueberryStaking is
         );
 
         accelerationFee =
-            ((((_vest.priceInUnderlying * _vestTotal) / 1e18) *
+            ((((_vest.priceUnderlying * _vestTotal) / 1e18) *
                 _earlyUnlockPenaltyRatio) / 1e18) /
             (10 ** (18 - stableDecimals));
     }

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -283,6 +283,7 @@ contract BlueberryStaking is
 
             if (redistributedBLB > 0) {
                 vest.extra = (vest.amount * uint128(redistributedBLB)) / uint128(totalVestAmount);
+                vest.extra = (vest.amount * uint128(redistributedBLB)) / uint128(totalVestAmount);
             }
         }
 
@@ -293,7 +294,7 @@ contract BlueberryStaking is
     function startVesting(
         address[] calldata _ibTokens
     ) external whenNotPaused updateRewards(msg.sender, _ibTokens) {
-        uint256 totalRewards;
+        uint128 totalRewards;
 
         uint256 _ibTokensLength = _ibTokens.length;
         for (uint256 i; i < _ibTokensLength; ++i) {
@@ -317,6 +318,10 @@ contract BlueberryStaking is
         }
 
         totalVestAmount += totalRewards;
+
+        vesting[msg.sender].push(
+            Vest(totalRewards, 0, uint128(block.timestamp), getPrice())
+        );
 
         emit VestStarted(msg.sender, totalRewards);
     }
@@ -450,7 +455,7 @@ contract BlueberryStaking is
     //////////////////////////////////////////////////*/
 
     /// @inheritdoc IBlueberryStaking
-    function getPrice() public view returns (uint128 _price) {
+    function getPrice() public view returns (uint256 _price) {
         // during the lockdrop period the underlying blb token price is locked
         uint256 _period = (block.timestamp - deployedAt) /
             (LOCKDROP_DURATION / 2);
@@ -581,7 +586,7 @@ contract BlueberryStaking is
         );
 
         accelerationFee =
-            ((((_vest.priceUnderlying * _vestTotal) / 1e18) *
+            ((((_vest.priceInUnderlying * _vestTotal) / 1e18) *
                 _earlyUnlockPenaltyRatio) / 1e18) /
             (10 ** (18 - stableDecimals));
     }

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -102,13 +102,13 @@ interface IBlueberryStaking {
      * @param amount The amount of tokens vested
      * @param extra The extra amount of tokens to be redistributed to this vesting schedule
      * @param startTime The start time of the vesting schedule
-     * @param priceUnderlying The underlying token Price
+     * @param priceInUnderlying The price of BLB in the stable asset at the time of vesting
      */
     struct Vest {
         uint128 amount;
         uint128 extra;
         uint128 startTime;
-        uint128 priceUnderlying;
+        uint128 priceInUnderlying;
     }
 
     /**

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -102,13 +102,13 @@ interface IBlueberryStaking {
      * @param amount The amount of tokens vested
      * @param extra The extra amount of tokens to be redistributed to this vesting schedule
      * @param startTime The start time of the vesting schedule
-     * @param priceInUnderlying The price of BLB in the stable asset at the time of vesting
+     * @param priceUnderlying The underlying token Price
      */
     struct Vest {
         uint128 amount;
         uint128 extra;
         uint128 startTime;
-        uint128 priceInUnderlying;
+        uint128 priceUnderlying;
     }
 
     /**


### PR DESCRIPTION
# Description

**This PR builds off of PR #27.**

Currently when a user calls `startVesting` it creates one `vestIndex` per `ibToken`. This is massively inefficient by creating fragmented vesting data and up to 11 storage writes per function call. By waiting until the end of the function call, after we have finished iterating over each `ibToken`, we can push the sum of all user rewards, `totalReward` into a singular storage write allowing for a cheaper experience for users and a significant improvement to Dev UX when integrating `BlueberryStaking` within the front-end and backend.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [x] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
