### PR TITLE
[M-03] Rewards will be permanently lost for ibToken with no deposits

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -641,7 +641,10 @@ contract BlueberryStaking is
             isIbToken[_ibToken] = true;
             ibTokens.push(_ibToken);
 
-            finishAt[_ibToken] = block.timestamp + _rewardDuration;
+            uint256 currentTimestamp = block.timestamp;
+            lastUpdateTime[_ibToken] = currentTimestamp;
+            finishAt[_ibToken] = currentTimestamp + _rewardDuration;
+
             _totalRewardsAdded += _amount;
 
             _setRewardRate(_ibToken, _amount, _rewardDuration);

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -518,6 +518,10 @@ contract BlueberryStaking is
     function lastTimeRewardApplicable(
         address ibToken
     ) public view returns (uint256) {
+        if (totalSupply[ibToken] == 0) {
+            return lastUpdateTime[ibToken];
+        }
+
         if (block.timestamp > finishAt[ibToken]) {
             return finishAt[ibToken];
         } else {


### PR DESCRIPTION
# Description

**Issue M-03:**
When distributing rewards, the reward rate and elapsed time are used to determine the number of tokens to distribute. If no `ibToken`s are deposited, rewards cannot be distributed, however the timestamp in this scenario is still updated. This leads all rewards during this period to be lost.

Additionally rewards are added at the same time that `ibToken`s are registered and allowed to be deposited. This causes a guaranteed loss of some rewards for every` ibToken`. The longer it goes before the first deposit the more tokens that are lost.

**Resolution:**
The PR updates `lastTimeRewardApplicable` to check for the `totalSupply` of a given `ibToken`. In the event that there has been none supplied into `BlueberryStaking`, `lastUpdateTime` will not be updated. This will protect us from losing rewards in the event noone has staked an `ibToken`

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
