### PR TITLE
H-01 & M-01 | UniswapV3 TWAP

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
-name: test
+name: Tests
 
-on: workflow_dispatch
+on: push
 
 env:
   FOUNDRY_PROFILE: ci
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
 
-    name: Foundry project
+    name: Staking Repository Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: push
 
 env:
   FOUNDRY_PROFILE: ci
+  MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
 
 jobs:
   check:

--- a/example.env
+++ b/example.env
@@ -1,0 +1,1 @@
+MAINNET_RPC_URL=

--- a/foundry.toml
+++ b/foundry.toml
@@ -19,3 +19,6 @@ remappings = [
     "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",
     "@openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
 ]
+
+[rpc_endpoints]
+mainnet = "${MAINNET_RPC_URL}"

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -833,15 +833,17 @@ contract BlueberryStaking is
             FixedPoint96.Q96
         );
 
-        uint256 scaler = 10 ** (18 + BLB_DECIMALS - stableDecimals);
-
         if (_uniswapV3Info.blbIsToken0) {
             return
-                FullMath.mulDiv(_priceX96, scaler, UNISWAP_PRICING_DENOMINATOR);
+                FullMath.mulDiv(
+                    _priceX96,
+                    10 ** (18 + BLB_DECIMALS - stableDecimals),
+                    UNISWAP_PRICING_DENOMINATOR
+                );
         } else {
             uint256 inversePrice = FullMath.mulDiv(
                 _priceX96,
-                scaler,
+                10 ** (18 - BLB_DECIMALS + stableDecimals),
                 UNISWAP_PRICING_DENOMINATOR
             );
             return 10 ** 36 / inversePrice;

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -831,18 +831,18 @@ contract BlueberryStaking is
 
         if (_uniswapV3Info.blbIsToken0) {
             return
-                FullMath.mulDiv(
+                uint128(FullMath.mulDiv(
                     _priceX96,
                     10 ** (18 + BLB_DECIMALS - stableDecimals),
                     UNISWAP_PRICING_DENOMINATOR
-                );
+                ));
         } else {
             uint256 inversePrice = FullMath.mulDiv(
                 _priceX96,
                 10 ** (18 - BLB_DECIMALS + stableDecimals),
                 UNISWAP_PRICING_DENOMINATOR
             );
-            return 10 ** 36 / inversePrice;
+            return uint128(10 ** 36 / inversePrice);
         }
     }
 

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -116,10 +116,12 @@ interface IBlueberryStaking {
      * @dev This is used to fetch the price of BLB in the stable asset
      * @param pool The address of the Uniswap V3 pool
      * @param observationPeriod The observation period for the Uniswap V3 pool
+     * @param blbIsToken0 True if BLB is token0 in the pool, false if BLB is token1
      */
     struct UniswapV3PoolInfo {
         address pool;
         uint32 observationPeriod;
+        bool blbIsToken0;
     }
 
     /*//////////////////////////////////////////////////

--- a/test/TwapPricing.t.sol
+++ b/test/TwapPricing.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+import {MockUniV3Oracle} from "./mocks/MockUniV3Oracle.sol";
+
+contract Control is Test {
+
+    uint256 mainnetFork;
+    MockUniV3Oracle mockUniV3Oracle;
+    string MAINNET_RPC_URL = vm.envString("MAINNET_RPC_URL");
+
+    function setUp() public {
+        mainnetFork = vm.createFork(MAINNET_RPC_URL);
+        vm.selectFork(mainnetFork);
+        mockUniV3Oracle = new MockUniV3Oracle();
+    }
+
+    /// Test get price when WETH is the target token and token0
+    function testGetPriceToken0() public {
+        mockUniV3Oracle.setPool(
+            0x11b815efB8f581194ae79006d24E0d814B7697F6,
+            3600,
+            0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+        );
+        console2.log("Price: %s", mockUniV3Oracle.getPrice());
+        assertGt(mockUniV3Oracle.getPrice(), 2800e18);
+        assertLt(mockUniV3Oracle.getPrice(), 3500e18);
+    }
+
+    /// Test get price when WETH is the target token and token1
+    function testGetPriceToken1() public {
+        mockUniV3Oracle.setPool(
+            0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640,
+            3600,
+            0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+        );
+        console2.log("Price: %s", mockUniV3Oracle.getPrice());
+        assertGt(mockUniV3Oracle.getPrice(), 2800e18);
+        assertLt(mockUniV3Oracle.getPrice(), 3500e18);
+    }
+}

--- a/test/mocks/MockUniV3Oracle.sol
+++ b/test/mocks/MockUniV3Oracle.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {IUniswapV3Pool} from "v3-core/interfaces/IUniswapV3Pool.sol";
+import "v3-core/libraries/TickMath.sol";
+import "v3-core/libraries/FullMath.sol";
+import "v3-core/libraries/FixedPoint96.sol";
+
+contract MockUniV3Oracle {
+
+    address public pool;
+    address public token0;
+    address public token1;
+    uint32 observationPeriod;
+    bool public targetIsToken0;
+
+    /// @notice The denominator for the Uniswap pricing calculations
+    uint256 private constant UNISWAP_PRICING_DENOMINATOR = 2 ** 96;
+
+    function setPool(
+        address _pool,
+        uint32 _observationPeriod,
+        address _targetToken
+    ) public {
+        pool = _pool;
+        token0 = IUniswapV3Pool(_pool).token0();
+        token1 = IUniswapV3Pool(_pool).token1();
+        observationPeriod = _observationPeriod;
+        targetIsToken0 = _targetToken == token0;
+    }
+
+    function getPrice() public view returns (uint256) {
+        IUniswapV3Pool _pool = IUniswapV3Pool(pool);
+
+        uint32[] memory _secondsArray = new uint32[](2);
+
+        _secondsArray[0] = observationPeriod;
+        _secondsArray[1] = 0;
+
+        (int56[] memory tickCumulatives, ) = _pool.observe(_secondsArray);
+
+        int56 _tickDifference = tickCumulatives[1] - tickCumulatives[0];
+        int56 _timeDifference = int32(observationPeriod);
+
+        int24 _twapTick = int24(_tickDifference / _timeDifference);
+
+        uint160 _sqrtPriceX96 = TickMath.getSqrtRatioAtTick(_twapTick);
+
+        // Decode the square root price
+        uint256 _priceX96 = FullMath.mulDiv(
+            _sqrtPriceX96,
+            _sqrtPriceX96,
+            FixedPoint96.Q96
+        );
+
+        uint256 token0Decimals = ERC20(token0).decimals();
+        uint256 token1Decimals = ERC20(token1).decimals();
+
+        if (targetIsToken0) {
+            return
+                FullMath.mulDiv(_priceX96, 10**(18 + token0Decimals - token1Decimals), UNISWAP_PRICING_DENOMINATOR);
+        } else {
+            uint256 inversePrice = FullMath.mulDiv(
+                _priceX96,
+                10**(18 - token1Decimals + token0Decimals),
+                UNISWAP_PRICING_DENOMINATOR
+            );
+            return 10 ** 36 / inversePrice;
+        }
+    }
+}


### PR DESCRIPTION
# Description
This PR fixes the TWAP oracle calculations for BLB/stable by introducing a pricing formula that can adapt to any pool whether `BLB` is `token0` or `token1` in a Uniswap pair. Additionally we introduce the `UniswapV3PoolInfo` struct to store persistent data about the pair along with if `blbIsToken0`.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
